### PR TITLE
Fix resolving module specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.1] - 22026-04-29
+
+### Fixed
+- Fix resolving module specifiers
+
 ## [v1.0.0] - 2026-04-29
 
 Initial Release

--- a/index.html
+++ b/index.html
@@ -8,10 +8,11 @@
 		<link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any" />
 		<script type="importmap" integrity="{{ INTEGRITY }}">{{ IMPORTMAP }}</script>
 		<script src="{{ POLYFILLS }}" referrerpolicy="no-referrer" crossorigin="anonymous" defer=""></script>
-		<script type="application/json" name="routes">
+		<script type="application/json" name="routes">{
 			"/posts/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug": "/routes/blog.js",
-			"/search": "/routes/form.js"
-		</script>
+			"/search": "@aegisjsproject/atlas/routes/form.js",
+			"/foo": "@aegisjsproject/core/parsers/html.js"
+		}</script>
 		<script type="module" src="/index.js" referrerpolicy="no-referrer"></script>
 	</head>
 	<body>

--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 import { init, back, forward, reload } from '@aegisjsproject/atlas';
 
-init({
-	'/posts/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug': '/routes/blog.js',
-	'/search': '/routes/form.js',
-}, { root: 'main', preload: true });
+init('routes', { root: 'main', preload: true });
 
 const backButton = document.createElement('button');
 const forwardButton = document.createElement('button');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/atlas",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/atlas",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/atlas",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A client-side router library using `Navigation` & `URLPattern`",
   "keywords": [
     "router",

--- a/preload.js
+++ b/preload.js
@@ -192,10 +192,7 @@ export async function preloadOnHover(target, {
 			const pattern = getRegistryKey(currentTarget.href);
 
 			if (pattern instanceof URLPattern) {
-				const specifier = getRegistrySpecifier(pattern);
-				const resolved = import.meta.resolve(specifier);
-
-				await preloadModule(resolved, {
+				await preloadModule(getRegistrySpecifier(pattern), {
 					fetchPriority,
 					referrerPolicy,
 					crossOrigin,

--- a/router.js
+++ b/router.js
@@ -164,9 +164,9 @@ export function init(routes, {
 	signal,
 } = {}) {
 	if (typeof routes === 'string') {
-		init(JSON.parse(document.scripts.namedItem(routes).textContent), { root, preload, signal });
+		init(JSON.parse(document.scripts.namedItem(routes).innerHTML), { root, preload, signal });
 	} else if (typeof routes === 'number') {
-		init(JSON.parse(document.scripts.item(routes).textContent), { root, preload, signal });
+		init(JSON.parse(document.scripts.item(routes).innerHTML), { root, preload, signal });
 	} else if (routes instanceof HTMLScriptElement) {
 		init(JSON.parse(routes.textContent), { root, preload, signal });
 	} else if (typeof routes === 'object') {

--- a/routes.js
+++ b/routes.js
@@ -3,6 +3,12 @@
  */
 const reg = new Map();
 
+const cache = new Map();
+
+const PATH_EXP = /^(?:\.*\/)+/;
+
+export const isBareSpecifier = specifier => ! PATH_EXP.test(specifier);
+
 /**
  * @typedef RouteMatch
  * @property {URLPatternResult|null} result The results of `pattern.exec(url)`
@@ -37,16 +43,37 @@ export const getRegistrySpecifier = key => reg.get(key);
  * @returns {RouteMatch}
  */
 export function lookupRoute(url) {
-	const key = getRegistryKey(url);
-
-	if (key instanceof URLPattern) {
-		return Object.freeze({
-			result: key.exec(url),
-			specifier: reg.get(key),
-			hasRegExpGroups: key.hasRegExpGroups,
-		});
+	if (cache.has(url)) {
+		return cache.get(url);
 	} else {
-		return invalidMatchResult;
+		const key = getRegistryKey(url);
+
+		if (key instanceof URLPattern) {
+			const match = Object.freeze({
+				result: key.exec(url),
+				specifier: reg.get(key),
+				hasRegExpGroups: key.hasRegExpGroups,
+			});
+
+			cache.set(url, match);
+			return match;
+		} else {
+			cache.set(url, invalidMatchResult);
+			return invalidMatchResult;
+		}
+
+	}
+}
+
+function resolveSpecifier(specifier) {
+	if (isBareSpecifier(specifier)) {
+		return import.meta.resolve(specifier);
+	} else if (URL.canParse(specifier)) {
+		return specifier;
+	} else if (specifier instanceof URL) {
+		return specifier.href;
+	} else {
+		return new URL (specifier, document.baseURI).href;
 	}
 }
 
@@ -62,13 +89,11 @@ export function registerModule(pattern, specifier) {
 	} else if (typeof pattern === 'string') {
 		reg.set(
 			URL.canParse(pattern) ? new URLPattern(pattern) : new URLPattern({ pathname: pattern }),
-			specifier.toString()
+			resolveSpecifier(specifier)
 		);
 	} else if (! (pattern instanceof URLPattern)) {
 		throw new TypeError(`Invalid pattner "${pattern}".`);
-	} else if (specifier instanceof URL) {
-		reg.set(pattern, specifier.href);
-	} else  {
-		reg.set(pattern, specifier);
+	} else {
+		reg.set(pattern, resolveSpecifier(specifier));
 	}
 }


### PR DESCRIPTION
Preloading cannot handle bare specifiers, and `import()` & `import.meta.resolve()` are relative. So resolve to full URL on registry with some detection.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
